### PR TITLE
fix(build): set the upper bounds of dependencies

### DIFF
--- a/aeson-tiled.cabal
+++ b/aeson-tiled.cabal
@@ -19,11 +19,11 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.Aeson.Tiled
   build-depends:       base       >= 4.7 && < 5
-                     , bytestring >= 0.10
-                     , aeson      >= 1.0
-                     , containers >= 0.5
-                     , text       >= 1.2
-                     , vector     >= 0.11
+                     , bytestring >= 0.10 && < 1
+                     , aeson      >= 1.0 && < 2
+                     , containers >= 0.5 && < 1
+                     , text       >= 1.2 && < 2
+                     , vector     >= 0.11 && < 1
   default-language:    Haskell2010
 
 executable aeson-tiled-exe


### PR DESCRIPTION
The latest commit on the master branch fails to compile. This commit
sets the upper limits of dependencies to prevent this error.
